### PR TITLE
Feature to provide multiple 'without' parameter as csv

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Automatically injects script tags into a page. Nice for auto put script tags in 
             srcs: ['src/frontend/modules/app.js', 'src/frontend/modules/*/*.js', 'src/frontend/modules/*/*/*.js'], //order is important if this sciprt will be concated and minified
             html: 'src/application.html', //file that as the block comment to look for a place to insert the script tags
             without: 'src/' //this script will be used to remove this block of string of script tag file location
+            withoutsCsv: 'src/,src/multi/' //this script will be used to remove multiple block of string of script tag file location
         }
     }
 

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -32,13 +32,22 @@ module.exports = function (grunt) {
                     }
                 }
             }
+            var withouts = [];
 
-            if (!this.data.without) {
-                this.data.without = '';
+            if (this.data.without) {
+               withouts.push(this.data.without);
             }
-
+            if (this.data.withoutsCsv) {
+               var splited = this.data.withoutsCsv.split(',');
+               for(var k=0;k<splited.length;k++){
+                   withouts.push(splited[k]);
+               }
+            }
             for (var i = 0; i < vector.length; i++) {
-                sources[i] = vector[i].replace(this.data.without, "");
+                sources[i] =vector[i];
+                for(var j=0;j<withouts.length;j++){
+                    sources[i] =sources[i].replace(withouts[j], "");
+                }
                 grunt.log.ok("source: " + sources[i]);
             }
         } else {


### PR DESCRIPTION
Added option to provide multiple 'without' parameter as csv. The parameter is named as 'withoutsCsv'. This allows users to simply specify withouts as comma seperated string.